### PR TITLE
Added support for “bang” optionals in classes (by converting to quest…

### DIFF
--- a/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
@@ -94,7 +94,7 @@ public struct Tokenizer {
             
             return InstanceVariable(
                 name: name,
-                type: type!,
+                type: (type ?? "Type could not be inferred by Cuckoo").replacingOccurrences(of: "!", with: "?"),
                 accessibility: accessibility!,
                 setterAccessibility: setterAccessibility,
                 range: range!,

--- a/Tests/ClassTest.swift
+++ b/Tests/ClassTest.swift
@@ -58,6 +58,21 @@ class ClassTest: XCTestCase {
         verify(mock).optionalProperty.set(equal(to: 0))
     }
     
+    func testBangOptionalStringProperty() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.bangOptionalStringProperty.get).thenReturn(nil)
+            when(mock.bangOptionalStringProperty.set(anyString())).then { _ in called = true }
+        }
+
+        mock.bangOptionalStringProperty = "Set it"
+
+        XCTAssertNil(mock.bangOptionalStringProperty)
+        XCTAssertTrue(called)
+        _ = verify(mock).bangOptionalStringProperty.get
+        verify(mock).bangOptionalStringProperty.set(equal(to: "Set it"))
+    }
+
     func testNoReturn() {
         var called = false
         stub(mock) { mock in

--- a/Tests/Source/TestedClass.swift
+++ b/Tests/Source/TestedClass.swift
@@ -17,6 +17,8 @@ class TestedClass {
     
     lazy var optionalProperty: Int? = 0
 
+    var bangOptionalStringProperty: String! = ""
+
     func noReturn() {
     }
     


### PR DESCRIPTION
Hello,
when starting to use Cuckoo on our code, I ran into some compatibility issues. Cuckoo doesn't like all our code :-)

First I added support for vars with the ! instead of ? optional indicator.
Second I noticed that the converter would crash on a var without type that is being initialized inline:
var value = Int(5)
After some investigation it turns out that the tokenizer doesn't now the type of value and crashes the generator. Now at least there is some warning in the generated code. Its not ideal, but I thought I would share it with you to get some feedback on a better implementation.

Regards,

Louis