### PR TITLE
Fix/accesibility problem

### DIFF
--- a/Cuckoo.xcodeproj/project.pbxproj
+++ b/Cuckoo.xcodeproj/project.pbxproj
@@ -10,6 +10,10 @@
 		183D03FF1C4691C600EBAEF3 /* Cuckoo.h in Headers */ = {isa = PBXBuildFile; fileRef = 183D03FE1C4691C600EBAEF3 /* Cuckoo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		183D04061C4691C600EBAEF3 /* Cuckoo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 183D03FB1C4691C600EBAEF3 /* Cuckoo.framework */; };
 		183D04161C46926A00EBAEF3 /* CuckooFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 183D04151C46926A00EBAEF3 /* CuckooFunctions.swift */; };
+		B5777B281E13DBB7005BBA8F /* ClassForStubTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD432D11D9277D80023AADA /* ClassForStubTesting.swift */; };
+		B5777B2B1E13DBBB005BBA8F /* ClassWithOptionals.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCE2DE0F1E071389006E462C /* ClassWithOptionals.swift */; };
+		B5777B2C1E13DBBF005BBA8F /* TestedClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC70D0BB1D2AF40800014C5F /* TestedClass.swift */; };
+		B5777B2D1E13DBC3005BBA8F /* TestedProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC70D0BC1D2AF40800014C5F /* TestedProtocol.swift */; };
 		DC1A82B51D2D6BD500A217F0 /* FailTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1A82B31D2D6A2100A217F0 /* FailTest.swift */; };
 		DC4094EE1D211563006FB137 /* StubFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4094EC1D211563006FB137 /* StubFunction.swift */; };
 		DC4094EF1D211563006FB137 /* StubThrowingFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4094ED1D211563006FB137 /* StubThrowingFunction.swift */; };
@@ -38,8 +42,6 @@
 		DC70D0B11D2AB67000014C5F /* CallMatcherFunctionsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC70D0B01D2AB67000014C5F /* CallMatcherFunctionsTest.swift */; };
 		DC70D0B31D2AB6B900014C5F /* MatchableTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC70D0B21D2AB6B900014C5F /* MatchableTest.swift */; };
 		DC70D0B81D2ABA3100014C5F /* TestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC70D0B71D2ABA3100014C5F /* TestUtils.swift */; };
-		DC70D0BE1D2AF40800014C5F /* TestedClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC70D0BB1D2AF40800014C5F /* TestedClass.swift */; };
-		DC70D0BF1D2AF40800014C5F /* TestedProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC70D0BC1D2AF40800014C5F /* TestedProtocol.swift */; };
 		DC70D0C21D2AF4FF00014C5F /* ArgumentCaptorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC70D0C11D2AF4FF00014C5F /* ArgumentCaptorTest.swift */; };
 		DC70D0C51D2AFA8E00014C5F /* StubFunctionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC70D0C41D2AFA8E00014C5F /* StubFunctionTest.swift */; };
 		DC70D0C91D2AFAD200014C5F /* StubNoReturnFunctionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC70D0C81D2AFAD200014C5F /* StubNoReturnFunctionTest.swift */; };
@@ -50,7 +52,6 @@
 		DC70D0D41D2B026200014C5F /* VerificationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC70D0D31D2B026200014C5F /* VerificationTest.swift */; };
 		DC70D0D61D2B9FBE00014C5F /* ParameterMatcherTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC70D0D51D2B9FBE00014C5F /* ParameterMatcherTest.swift */; };
 		DC70D0D81D2B9FD400014C5F /* CallMatcherTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC70D0D71D2B9FD400014C5F /* CallMatcherTest.swift */; };
-		DC78DE2C1E0715BD00279900 /* ClassWithOptionals.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCE2DE0F1E071389006E462C /* ClassWithOptionals.swift */; };
 		DC9EF9FE1CFAD4F10034DFE5 /* Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9EF9FD1CFAD4F10034DFE5 /* Stub.swift */; };
 		DC9EFA001CFAD5660034DFE5 /* StubCall.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9EF9FF1CFAD5660034DFE5 /* StubCall.swift */; };
 		DC9EFA1A1CFADAD70034DFE5 /* Matchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9EFA161CFADAD70034DFE5 /* Matchable.swift */; };
@@ -62,7 +63,6 @@
 		DC9EFA461CFC43A70034DFE5 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9EFA451CFC43A70034DFE5 /* Utils.swift */; };
 		DCD432D01D926C0D0023AADA /* DefaultValueRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD432CF1D926C0D0023AADA /* DefaultValueRegistry.swift */; };
 		DCD432D51D9286D10023AADA /* StubTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD432D31D92868C0023AADA /* StubTest.swift */; };
-		DCD432D61D9286D50023AADA /* ClassForStubTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD432D11D9277D80023AADA /* ClassForStubTesting.swift */; };
 		DCD432D81D929B2A0023AADA /* DefaultValueRegistryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD432D71D929B2A0023AADA /* DefaultValueRegistryTest.swift */; };
 /* End PBXBuildFile section */
 
@@ -524,7 +524,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "OUTPUT=\"$PROJECT_DIR/Tests/Generated/GeneratedMocks.swift\"\n# Use seperate variables for each file.\nINPUT_STUB=\"$PROJECT_DIR/Tests/Source/ClassForStubTesting.swift\"\nINPUT_OPTIONAL=\"$PROJECT_DIR/Tests/Source/ClassWithOptionals.swift\"\nfor definition in $GCC_PREPROCESSOR_DEFINITIONS; do\n    if [ $definition = \"USE_RUN\" ]; then\n        use_run=1\n    fi\ndone\nif [ $use_run ]; then\n    \"$PROJECT_DIR/run\" --clean generate --output \"$OUTPUT\" \"$INPUT_STUB\" \"$INPUT_OPTIONAL\"\nelse\n    \"$BUILD_DIR/$CONFIGURATION/cuckoo_generator.app/Contents/MacOS/cuckoo_generator\" generate --output \"$OUTPUT\" \"$INPUT_STUB\" \"$INPUT_OPTIONAL\" \"$PROJECT_DIR/Tests/Source/TestedProtocol.swift\" \"$PROJECT_DIR/Tests/Source/TestedClass.swift\"\nfi";
+			shellScript = "OUTPUT=\"$PROJECT_DIR/Tests/Generated/GeneratedMocks.swift\"\n# Use seperate variables for each file.\nINPUT_STUB=\"$PROJECT_DIR/Tests/Source/ClassForStubTesting.swift\"\nINPUT_OPTIONAL=\"$PROJECT_DIR/Tests/Source/ClassWithOptionals.swift\"\nfor definition in $GCC_PREPROCESSOR_DEFINITIONS; do\n    if [ $definition = \"USE_RUN\" ]; then\n        use_run=1\n    fi\ndone\nif [ $use_run ]; then\n    \"$PROJECT_DIR/run\" --clean generate --testable Cuckoo --output \"$OUTPUT\" \"$INPUT_STUB\" \"$INPUT_OPTIONAL\"\nelse\n    \"$BUILD_DIR/$CONFIGURATION/cuckoo_generator.app/Contents/MacOS/cuckoo_generator\" generate --testable Cuckoo --output \"$OUTPUT\" \"$INPUT_STUB\" \"$INPUT_OPTIONAL\" \"$PROJECT_DIR/Tests/Source/TestedProtocol.swift\" \"$PROJECT_DIR/Tests/Source/TestedClass.swift\"\nfi";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -542,10 +542,13 @@
 				DC4095011D2120D0006FB137 /* StubFunctionThenDoNothingTrait.swift in Sources */,
 				DC4094EE1D211563006FB137 /* StubFunction.swift in Sources */,
 				183D04161C46926A00EBAEF3 /* CuckooFunctions.swift in Sources */,
+				B5777B2C1E13DBBF005BBA8F /* TestedClass.swift in Sources */,
+				B5777B2D1E13DBC3005BBA8F /* TestedProtocol.swift in Sources */,
 				DC4094F41D211598006FB137 /* ToBeStubbedReadOnlyProperty.swift in Sources */,
 				DC9EFA401CFC2FE20034DFE5 /* VerificationProxy.swift in Sources */,
 				DC9EFA001CFAD5660034DFE5 /* StubCall.swift in Sources */,
 				DC9EFA3E1CFC2FE20034DFE5 /* Mock.swift in Sources */,
+				B5777B281E13DBB7005BBA8F /* ClassForStubTesting.swift in Sources */,
 				DC4094FF1D2116DA006FB137 /* StubFunctionThenTrait.swift in Sources */,
 				DC9EFA421CFC31B10034DFE5 /* StubAction.swift in Sources */,
 				DC4094F31D211598006FB137 /* ToBeStubbedProperty.swift in Sources */,
@@ -561,6 +564,7 @@
 				DC9EFA2D1CFAE16C0034DFE5 /* MockManager.swift in Sources */,
 				DC4095261D2A50BE006FB137 /* ParameterMatcherFunctions.swift in Sources */,
 				DC4095281D2A50CC006FB137 /* CallMatcherFunctions.swift in Sources */,
+				B5777B2B1E13DBBB005BBA8F /* ClassWithOptionals.swift in Sources */,
 				DC4094F71D2116B1006FB137 /* BaseStubFunctionTrait.swift in Sources */,
 				DC4094FD1D2116DA006FB137 /* StubFunctionThenCallRealImplementationTrait.swift in Sources */,
 				DC4095091D2120E6006FB137 /* StubNoReturnThrowingFunction.swift in Sources */,
@@ -579,15 +583,11 @@
 				DC70D0B11D2AB67000014C5F /* CallMatcherFunctionsTest.swift in Sources */,
 				DCD432D81D929B2A0023AADA /* DefaultValueRegistryTest.swift in Sources */,
 				DCD432D51D9286D10023AADA /* StubTest.swift in Sources */,
-				DC70D0BF1D2AF40800014C5F /* TestedProtocol.swift in Sources */,
 				DC70D0CF1D2AFD0D00014C5F /* StubbingTest.swift in Sources */,
 				DC70D0AF1D2AB64A00014C5F /* ParameterMatcherFunctionsTest.swift in Sources */,
 				DC70D0D61D2B9FBE00014C5F /* ParameterMatcherTest.swift in Sources */,
-				DCD432D61D9286D50023AADA /* ClassForStubTesting.swift in Sources */,
 				DC70D0AB1D2AB5F800014C5F /* ClassTest.swift in Sources */,
-				DC78DE2C1E0715BD00279900 /* ClassWithOptionals.swift in Sources */,
 				DC70D0B31D2AB6B900014C5F /* MatchableTest.swift in Sources */,
-				DC70D0BE1D2AF40800014C5F /* TestedClass.swift in Sources */,
 				DC70D0D21D2B007300014C5F /* GeneratedMocks.swift in Sources */,
 				DC1A82B51D2D6BD500A217F0 /* FailTest.swift in Sources */,
 				DC70D0D41D2B026200014C5F /* VerificationTest.swift in Sources */,

--- a/Tests/CuckooFunctionsTest.swift
+++ b/Tests/CuckooFunctionsTest.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import Cuckoo
+@testable import Cuckoo
 
 class CuckooFunctionsTest: XCTestCase {
        

--- a/Tests/FailTest.swift
+++ b/Tests/FailTest.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import Cuckoo
+@testable import Cuckoo
 
 class FailTest: XCTestCase {
     

--- a/Tests/Source/TestedClass.swift
+++ b/Tests/Source/TestedClass.swift
@@ -47,3 +47,45 @@ class TestedClass {
     func withLabelAndUnderscore(labelA a: String, _ b: String) {
     }
 }
+
+// Notice the subtle difference, this class is public. The generated code does not compile.
+public class PublicTestedClass {
+    let constant: Float = 0.0
+
+    var readOnlyProperty: String {
+        return "a"
+    }
+
+    lazy var readWriteProperty: Int = 0
+
+    lazy var optionalProperty: Int? = 0
+
+    func noReturn() {
+    }
+
+    func count(characters: String) -> Int {
+        return characters.characters.count
+    }
+
+    func withThrows() throws -> Int {
+        return 0
+    }
+
+    func withNoReturnThrows() throws {
+    }
+
+    func withClosure(_ closure: (String) -> Int) -> Int {
+        return closure("hello")
+    }
+
+    func withEscape(_ a: String, action closure: @escaping (String) -> Void) {
+        closure(a)
+    }
+
+    func withOptionalClosure(_ a: String, closure: ((String) -> Void)?) {
+        closure?(a)
+    }
+
+    func withLabelAndUnderscore(labelA a: String, _ b: String) {
+    }
+}

--- a/Tests/Source/TestedClass.swift
+++ b/Tests/Source/TestedClass.swift
@@ -89,3 +89,44 @@ public class PublicTestedClass {
     func withLabelAndUnderscore(labelA a: String, _ b: String) {
     }
 }
+
+public class PublicPublicTestedClass {
+    public let constant: Float = 0.0
+
+    public var readOnlyProperty: String {
+        return "a"
+    }
+
+    public lazy var readWriteProperty: Int = 0
+
+    public lazy var optionalProperty: Int? = 0
+
+    public func noReturn() {
+    }
+
+    public func count(characters: String) -> Int {
+        return characters.characters.count
+    }
+
+    public func withThrows() throws -> Int {
+        return 0
+    }
+
+    public func withNoReturnThrows() throws {
+    }
+
+    public func withClosure(_ closure: (String) -> Int) -> Int {
+        return closure("hello")
+    }
+
+    public func withEscape(_ a: String, action closure: @escaping (String) -> Void) {
+        closure(a)
+    }
+
+    public func withOptionalClosure(_ a: String, closure: ((String) -> Void)?) {
+        closure?(a)
+    }
+
+    public func withLabelAndUnderscore(labelA a: String, _ b: String) {
+    }
+}

--- a/Tests/Stubbing/StubFunctionTest.swift
+++ b/Tests/Stubbing/StubFunctionTest.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import Cuckoo
+@testable import Cuckoo
 
 class StubFunctionTest: XCTestCase {
     

--- a/Tests/Stubbing/StubNoReturnFunctionTest.swift
+++ b/Tests/Stubbing/StubNoReturnFunctionTest.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import Cuckoo
+@testable import Cuckoo
 
 class StubNoReturnFunctionTest: XCTestCase {
     

--- a/Tests/Stubbing/StubNoReturnThrowingFunctionTest.swift
+++ b/Tests/Stubbing/StubNoReturnThrowingFunctionTest.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import Cuckoo
+@testable import Cuckoo
 
 class StubNoReturnThrowingFunctionTest: XCTestCase {
     

--- a/Tests/Stubbing/StubThrowingFunctionTest.swift
+++ b/Tests/Stubbing/StubThrowingFunctionTest.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import Cuckoo
+@testable import Cuckoo
 
 class StubThrowingFunctionTest: XCTestCase {
     

--- a/Tests/Stubbing/StubbingTest.swift
+++ b/Tests/Stubbing/StubbingTest.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import Cuckoo
+@testable import Cuckoo
 
 class StubbingTest: XCTestCase {
     


### PR DESCRIPTION
It seems that the setup of the Test target is slightly off (it contains the tests as well as the code under test in the same target). This gives rise to subtle accessibility problems. The access modifier of the containing class and the access modifier of the func, var need to be used to calculate the proper access modifiers. Please check and suggest ways to test it.