### PR TITLE
Throw exception instead of fatalError when possible

### DIFF
--- a/Source/MockManager.swift
+++ b/Source/MockManager.swift
@@ -118,6 +118,11 @@ public class MockManager {
     
     private func failAndCrash(_ message: String, file: StaticString = #file, line: UInt = #line) -> Never  {
         MockManager.fail(message, (file, line))
+
+        #if _runtime(_ObjC)
+            NSException(name: .internalInconsistencyException, reason:message, userInfo: nil).raise()
+        #endif
+
         fatalError(message)
     }
 }


### PR DESCRIPTION
This change is attributed to https://github.com/Quick/Quick/blob/master/Sources/Quick/ErrorUtility.swift

I wasn't able to get the test project setup to verify that tests were still passing