### PR TITLE
Generate empty init functions when generating a mock from a protocol.

### DIFF
--- a/Tests/Source/TestedProtocol.swift
+++ b/Tests/Source/TestedProtocol.swift
@@ -29,4 +29,8 @@ protocol TestedProtocol {
     func withOptionalClosure(_ a: String, closure: ((String) -> Void)?)
 
     func withLabelAndUnderscore(labelA a: String, _ b: String)
+
+    init()
+
+    init(labelA a: String, _ b: String)
 }


### PR DESCRIPTION
I'm not to happy about passing the fromProtocolDefinition flag around, but I couldn't find a way to find the enclosing class or protocol declaration token. Would extending the Token with a parent be acceptable?