### PR TITLE
Handle open accessibility as public

### DIFF
--- a/Generator/Source/CuckooGeneratorFramework/Generator.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Generator.swift
@@ -64,6 +64,11 @@ public struct Generator {
     }
 
     private func minAccessibility(_ val1: Accessibility, _ val2: Accessibility) -> Accessibility {
+
+        if val1 == .Open || val2 == .Open {
+            return .Open
+        }
+
         if val1 == .Public || val2 == .Public {
             return .Public
         }

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/Accessibility.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/Accessibility.swift
@@ -7,6 +7,7 @@
 //
 
 public enum Accessibility: String {
+    case Open = "source.lang.swift.accessibility.open"
     case Public = "source.lang.swift.accessibility.public"
     case Internal = "source.lang.swift.accessibility.internal"
     case Private = "source.lang.swift.accessibility.private"
@@ -14,6 +15,8 @@ public enum Accessibility: String {
 
     public var sourceName: String {
         switch self {
+        case .Open:
+            fallthrough
         case .Public:
             return "public "
         case .Internal:

--- a/Tests/Source/TestedClass.swift
+++ b/Tests/Source/TestedClass.swift
@@ -62,6 +62,15 @@ private class ThisClassShouldNotBeMocked1 {
     var property: Int?
 }
 
+open class OpenTestedClass {
+
+    let constant = 1
+
+    open func printConstant() {
+        print(constant)
+    }
+}
+
 fileprivate class ThisClassShouldNotBeMocked2 {
     var property: Int?
     // How to test that the expected output is generated??


### PR DESCRIPTION
Today Cuckoo can't generate mocks/stubs for classes with open accessibility. This Pull Requests changes roughly the behavior to handle open as public and that way be able to generate the mocks/stubs.