### PR TITLE
Inheritance support for Classes and Protocols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ Carthage/Build
 default.profraw
 Tests/Generated/*.swift
 Generator/*.app
+
+# AppCode
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.4
+
+* Added support for inheritance mocking.  
+
 ## 0.8.3
 
 * Added support for `fileprivate` (thanks to lvdstam for implementation).

--- a/Cuckoo.podspec
+++ b/Cuckoo.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Cuckoo"
-  s.version          = "0.8.3"
+  s.version          = "0.8.4"
   s.summary          = "Cuckoo - first boilerplate-free Swift mocking framework."
   s.description      = <<-DESC
                         Cuckoo is a mocking framework with an easy to use API (inspired by Mockito).
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
 
   s.homepage         = "https://github.com/SwiftKit/Cuckoo"
   s.license          = 'MIT'
-  s.author           = { "Tadeas Kriz" => "tadeas@brightify.org", "Filip Dolnik" => "filip@brightify.org" }
+  s.author           = { "Tadeas Kriz" => "tadeas@brightify.org", "Filip Dolnik" => "filip@brightify.org", "Adriaan (Arjan) Duijzer" => "arjan@nxtstep.nl" }
   s.source           = {
       :git => "https://github.com/SwiftKit/Cuckoo.git",
       :tag => s.version.to_s

--- a/Cuckoo.xcodeproj/project.pbxproj
+++ b/Cuckoo.xcodeproj/project.pbxproj
@@ -10,10 +10,13 @@
 		183D03FF1C4691C600EBAEF3 /* Cuckoo.h in Headers */ = {isa = PBXBuildFile; fileRef = 183D03FE1C4691C600EBAEF3 /* Cuckoo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		183D04061C4691C600EBAEF3 /* Cuckoo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 183D03FB1C4691C600EBAEF3 /* Cuckoo.framework */; };
 		183D04161C46926A00EBAEF3 /* CuckooFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 183D04151C46926A00EBAEF3 /* CuckooFunctions.swift */; };
-		B5777B281E13DBB7005BBA8F /* ClassForStubTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD432D11D9277D80023AADA /* ClassForStubTesting.swift */; };
-		B5777B2B1E13DBBB005BBA8F /* ClassWithOptionals.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCE2DE0F1E071389006E462C /* ClassWithOptionals.swift */; };
-		B5777B2C1E13DBBF005BBA8F /* TestedClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC70D0BB1D2AF40800014C5F /* TestedClass.swift */; };
-		B5777B2D1E13DBC3005BBA8F /* TestedProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC70D0BC1D2AF40800014C5F /* TestedProtocol.swift */; };
+		58C54ADE34CFF59ECB7C5EE2 /* TestedSubProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C549CFCF27949160520C92 /* TestedSubProtocol.swift */; };
+		58C54E7336161DFE7C1296FF /* GeneratedMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C5439B933469D27553A0B4 /* GeneratedMocks.swift */; };
+		D65C5BFA1E57379100D25697 /* ClassForStubTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD432D11D9277D80023AADA /* ClassForStubTesting.swift */; };
+		D65C5BFD1E57379400D25697 /* ClassWithOptionals.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCE2DE0F1E071389006E462C /* ClassWithOptionals.swift */; };
+		D65C5BFE1E57379700D25697 /* TestedClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC70D0BB1D2AF40800014C5F /* TestedClass.swift */; };
+		D65C5BFF1E57379A00D25697 /* TestedProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC70D0BC1D2AF40800014C5F /* TestedProtocol.swift */; };
+		D65C5C031E573BCC00D25697 /* TestedSubclass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D65C5C021E573BCC00D25697 /* TestedSubclass.swift */; };
 		DC1A82B51D2D6BD500A217F0 /* FailTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1A82B31D2D6A2100A217F0 /* FailTest.swift */; };
 		DC4094EE1D211563006FB137 /* StubFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4094EC1D211563006FB137 /* StubFunction.swift */; };
 		DC4094EF1D211563006FB137 /* StubThrowingFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4094ED1D211563006FB137 /* StubThrowingFunction.swift */; };
@@ -98,6 +101,8 @@
 		183D040C1C4691C600EBAEF3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		183D04151C46926A00EBAEF3 /* CuckooFunctions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CuckooFunctions.swift; sourceTree = "<group>"; };
 		18F03D881DE454F50006A71E /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
+		58C549CFCF27949160520C92 /* TestedSubProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestedSubProtocol.swift; sourceTree = "<group>"; };
+		D65C5C021E573BCC00D25697 /* TestedSubclass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestedSubclass.swift; sourceTree = "<group>"; };
 		DC1A82B31D2D6A2100A217F0 /* FailTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FailTest.swift; sourceTree = "<group>"; };
 		DC4094EC1D211563006FB137 /* StubFunction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StubFunction.swift; sourceTree = "<group>"; };
 		DC4094ED1D211563006FB137 /* StubThrowingFunction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StubThrowingFunction.swift; sourceTree = "<group>"; };
@@ -316,6 +321,8 @@
 				DCE2DE0F1E071389006E462C /* ClassWithOptionals.swift */,
 				DC70D0BB1D2AF40800014C5F /* TestedClass.swift */,
 				DC70D0BC1D2AF40800014C5F /* TestedProtocol.swift */,
+				D65C5C021E573BCC00D25697 /* TestedSubclass.swift */,
+				58C549CFCF27949160520C92 /* TestedSubProtocol.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -524,7 +531,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "OUTPUT=\"$PROJECT_DIR/Tests/Generated/GeneratedMocks.swift\"\n# Use seperate variables for each file.\nINPUT_STUB=\"$PROJECT_DIR/Tests/Source/ClassForStubTesting.swift\"\nINPUT_OPTIONAL=\"$PROJECT_DIR/Tests/Source/ClassWithOptionals.swift\"\nfor definition in $GCC_PREPROCESSOR_DEFINITIONS; do\n    if [ $definition = \"USE_RUN\" ]; then\n        use_run=1\n    fi\ndone\nif [ $use_run ]; then\n    \"$PROJECT_DIR/run\" --clean generate --testable Cuckoo --output \"$OUTPUT\" \"$INPUT_STUB\" \"$INPUT_OPTIONAL\"\nelse\n    \"$BUILD_DIR/$CONFIGURATION/cuckoo_generator.app/Contents/MacOS/cuckoo_generator\" generate --testable Cuckoo --output \"$OUTPUT\" \"$INPUT_STUB\" \"$INPUT_OPTIONAL\" \"$PROJECT_DIR/Tests/Source/TestedProtocol.swift\" \"$PROJECT_DIR/Tests/Source/TestedClass.swift\"\nfi";
+			shellScript = "OUTPUT=\"$PROJECT_DIR/Tests/Generated/GeneratedMocks.swift\"\n# Use seperate variables for each file.\nINPUT_STUB=\"$PROJECT_DIR/Tests/Source/ClassForStubTesting.swift\"\nINPUT_OPTIONAL=\"$PROJECT_DIR/Tests/Source/ClassWithOptionals.swift\"\nfor definition in $GCC_PREPROCESSOR_DEFINITIONS; do\n    if [ $definition = \"USE_RUN\" ]; then\n        use_run=1\n    fi\ndone\nif [ $use_run ]; then\n    \"$PROJECT_DIR/run\" --clean generate --testable Cuckoo --output \"$OUTPUT\" \"$INPUT_STUB\" \"$INPUT_OPTIONAL\"\nelse\n    \"$BUILD_DIR/$CONFIGURATION/cuckoo_generator.app/Contents/MacOS/cuckoo_generator\" generate --testable Cuckoo --output \"$OUTPUT\" \"$INPUT_STUB\" \"$INPUT_OPTIONAL\" \"$PROJECT_DIR/Tests/Source/TestedProtocol.swift\" \"$PROJECT_DIR/Tests/Source/TestedClass.swift\" \"$PROJECT_DIR/Tests/Source/TestedSubclass.swift\"\nfi";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -542,13 +549,10 @@
 				DC4095011D2120D0006FB137 /* StubFunctionThenDoNothingTrait.swift in Sources */,
 				DC4094EE1D211563006FB137 /* StubFunction.swift in Sources */,
 				183D04161C46926A00EBAEF3 /* CuckooFunctions.swift in Sources */,
-				B5777B2C1E13DBBF005BBA8F /* TestedClass.swift in Sources */,
-				B5777B2D1E13DBC3005BBA8F /* TestedProtocol.swift in Sources */,
 				DC4094F41D211598006FB137 /* ToBeStubbedReadOnlyProperty.swift in Sources */,
 				DC9EFA401CFC2FE20034DFE5 /* VerificationProxy.swift in Sources */,
 				DC9EFA001CFAD5660034DFE5 /* StubCall.swift in Sources */,
 				DC9EFA3E1CFC2FE20034DFE5 /* Mock.swift in Sources */,
-				B5777B281E13DBB7005BBA8F /* ClassForStubTesting.swift in Sources */,
 				DC4094FF1D2116DA006FB137 /* StubFunctionThenTrait.swift in Sources */,
 				DC9EFA421CFC31B10034DFE5 /* StubAction.swift in Sources */,
 				DC4094F31D211598006FB137 /* ToBeStubbedProperty.swift in Sources */,
@@ -564,7 +568,6 @@
 				DC9EFA2D1CFAE16C0034DFE5 /* MockManager.swift in Sources */,
 				DC4095261D2A50BE006FB137 /* ParameterMatcherFunctions.swift in Sources */,
 				DC4095281D2A50CC006FB137 /* CallMatcherFunctions.swift in Sources */,
-				B5777B2B1E13DBBB005BBA8F /* ClassWithOptionals.swift in Sources */,
 				DC4094F71D2116B1006FB137 /* BaseStubFunctionTrait.swift in Sources */,
 				DC4094FD1D2116DA006FB137 /* StubFunctionThenCallRealImplementationTrait.swift in Sources */,
 				DC4095091D2120E6006FB137 /* StubNoReturnThrowingFunction.swift in Sources */,
@@ -577,6 +580,7 @@
 			files = (
 				DC70D0C21D2AF4FF00014C5F /* ArgumentCaptorTest.swift in Sources */,
 				DC70D0C91D2AFAD200014C5F /* StubNoReturnFunctionTest.swift in Sources */,
+				D65C5C031E573BCC00D25697 /* TestedSubclass.swift in Sources */,
 				DC70D0CD1D2AFB1100014C5F /* StubThrowingFunctionTest.swift in Sources */,
 				DC70D0CB1D2AFAF200014C5F /* StubNoReturnThrowingFunctionTest.swift in Sources */,
 				DC70D0B81D2ABA3100014C5F /* TestUtils.swift in Sources */,
@@ -586,15 +590,20 @@
 				DC70D0CF1D2AFD0D00014C5F /* StubbingTest.swift in Sources */,
 				DC70D0AF1D2AB64A00014C5F /* ParameterMatcherFunctionsTest.swift in Sources */,
 				DC70D0D61D2B9FBE00014C5F /* ParameterMatcherTest.swift in Sources */,
+				D65C5BFA1E57379100D25697 /* ClassForStubTesting.swift in Sources */,
 				DC70D0AB1D2AB5F800014C5F /* ClassTest.swift in Sources */,
 				DC70D0B31D2AB6B900014C5F /* MatchableTest.swift in Sources */,
 				DC70D0D21D2B007300014C5F /* GeneratedMocks.swift in Sources */,
 				DC1A82B51D2D6BD500A217F0 /* FailTest.swift in Sources */,
 				DC70D0D41D2B026200014C5F /* VerificationTest.swift in Sources */,
 				DC70D0AD1D2AB62100014C5F /* ProtocolTest.swift in Sources */,
+				D65C5BFF1E57379A00D25697 /* TestedProtocol.swift in Sources */,
+				D65C5BFE1E57379700D25697 /* TestedClass.swift in Sources */,
+				D65C5BFD1E57379400D25697 /* ClassWithOptionals.swift in Sources */,
 				DC70D0C51D2AFA8E00014C5F /* StubFunctionTest.swift in Sources */,
 				DC70D0D81D2B9FD400014C5F /* CallMatcherTest.swift in Sources */,
 				DC70D0A81D2AB5B700014C5F /* CuckooFunctionsTest.swift in Sources */,
+				58C54ADE34CFF59ECB7C5EE2 /* TestedSubProtocol.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Generator/CuckooGenerator.xcodeproj/project.pbxproj
+++ b/Generator/CuckooGenerator.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		18E16D871C45D8B30084EF54 /* FileHeaderHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E16D591C45A85E0084EF54 /* FileHeaderHandler.swift */; };
 		18E16D991C45DF7F0084EF54 /* Components.plist in Resources */ = {isa = PBXBuildFile; fileRef = 18E16D981C45DF7F0084EF54 /* Components.plist */; };
 		18F2BC1D1C46E8E30015A95F /* Generator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18F2BC1B1C46E8760015A95F /* Generator.swift */; };
+		D61BD5C11E5DB55B00CF3C72 /* InheritanceDeclaration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C54682D45C5A3614A6FA6A /* InheritanceDeclaration.swift */; };
 		DC4094301D13F91F006FB137 /* Import.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC40942E1D13F8FA006FB137 /* Import.swift */; };
 		DC4094861D140184006FB137 /* ExtensionDeclaration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4094651D140180006FB137 /* ExtensionDeclaration.swift */; };
 		DC5176351D2EE8F700E922F2 /* CodeBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5176331D2EE4D300E922F2 /* CodeBuilder.swift */; };
@@ -320,6 +321,7 @@
 		18E16D6A1C45D8280084EF54 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		18E16D981C45DF7F0084EF54 /* Components.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Components.plist; sourceTree = "<group>"; };
 		18F2BC1B1C46E8760015A95F /* Generator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Generator.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		58C54682D45C5A3614A6FA6A /* InheritanceDeclaration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InheritanceDeclaration.swift; sourceTree = "<group>"; };
 		DC1AB5D21D0D9F0B00867895 /* FileKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = FileKit.xcodeproj; path = Dependencies/FileKit/FileKit.xcodeproj; sourceTree = "<group>"; };
 		DC1AB5E41D0D9F1600867895 /* sourcekitten.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = sourcekitten.xcodeproj; path = Dependencies/SourceKitten/sourcekitten.xcodeproj; sourceTree = "<group>"; };
 		DC1AB60B1D0D9F8600867895 /* SWXMLHash.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SWXMLHash.xcodeproj; path = Dependencies/SourceKitten/Carthage/Checkouts/SWXMLHash/SWXMLHash.xcodeproj; sourceTree = "<group>"; };
@@ -519,6 +521,7 @@
 				DC9EFA5F1CFC4F420034DFE5 /* ProtocolDeclaration.swift */,
 				DC9EFA621CFC4F420034DFE5 /* ProtocolMethod.swift */,
 				DC9EFA5D1CFC4F420034DFE5 /* Token.swift */,
+				58C54682D45C5A3614A6FA6A /* InheritanceDeclaration.swift */,
 			);
 			path = Tokens;
 			sourceTree = "<group>";
@@ -932,6 +935,7 @@
 				DC9EFA901CFC50070034DFE5 /* ClassMethod.swift in Sources */,
 				DC9EFA7A1CFC4F4D0034DFE5 /* ClassDeclaration.swift in Sources */,
 				DC9EFA771CFC4F4D0034DFE5 /* Token.swift in Sources */,
+				D61BD5C11E5DB55B00CF3C72 /* InheritanceDeclaration.swift in Sources */,
 				DC4094301D13F91F006FB137 /* Import.swift in Sources */,
 				18E16D831C45D8B30084EF54 /* Utils.swift in Sources */,
 				DC9EFA7B1CFC4F4D0034DFE5 /* Method.swift in Sources */,

--- a/Generator/Source/CuckooGeneratorFramework/Supporting Files/Info.plist
+++ b/Generator/Source/CuckooGeneratorFramework/Supporting Files/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.8.3</string>
+	<string>0.8.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
@@ -42,7 +42,7 @@ public struct Tokenizer {
 
         // Inheritance
         let inheritedTypes = dictionary[Key.InheritedTypes.rawValue] as? [SourceKitRepresentable] ?? []
-        let tokenizedInheritedTypes = inheritedTypes.flatMap { type -> Token in
+        let tokenizedInheritedTypes = inheritedTypes.flatMap { type -> InheritanceDeclaration in
             guard let typeDict = type as? [String: SourceKitRepresentable] else {
                 return InheritanceDeclaration.empty
             }

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ClassDeclaration.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ClassDeclaration.swift
@@ -15,7 +15,7 @@ public struct ClassDeclaration: ContainerToken {
     public let initializers: [Initializer]
     public let children: [Token]
     public let implementation: Bool = true
-    public let inheritedTypes: [Token]
+    public let inheritedTypes: [InheritanceDeclaration]
     
     public var hasNoArgInit: Bool {
         return initializers.filter { $0.parameters.isEmpty }.isEmpty

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ClassDeclaration.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ClassDeclaration.swift
@@ -15,8 +15,25 @@ public struct ClassDeclaration: ContainerToken {
     public let initializers: [Initializer]
     public let children: [Token]
     public let implementation: Bool = true
+    public let inheritedTypes: [Token]
     
     public var hasNoArgInit: Bool {
         return initializers.filter { $0.parameters.isEmpty }.isEmpty
+    }
+
+    public func replace(children tokens: [Token]) -> ClassDeclaration {
+        return ClassDeclaration(name: self.name,
+                accessibility: self.accessibility,
+                range: self.range,
+                nameRange: self.nameRange,
+                bodyRange: self.bodyRange,
+                initializers: self.initializers,
+                children: tokens,
+                inheritedTypes: self.inheritedTypes)
+    }
+
+    public func isEqual(to other: Token) -> Bool {
+        guard let other = other as? ClassDeclaration else { return false }
+        return self.name == other.name
     }
 }

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ContainerToken.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ContainerToken.swift
@@ -15,5 +15,5 @@ public protocol ContainerToken: Token {
     var initializers: [Initializer] { get }
     var children: [Token] { get }
     var implementation: Bool { get }
-    var inheritedTypes: [Token] { get }
+    var inheritedTypes: [InheritanceDeclaration] { get }
 }

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ContainerToken.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ContainerToken.swift
@@ -15,4 +15,5 @@ public protocol ContainerToken: Token {
     var initializers: [Initializer] { get }
     var children: [Token] { get }
     var implementation: Bool { get }
+    var inheritedTypes: [Token] { get }
 }

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ExtensionDeclaration.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ExtensionDeclaration.swift
@@ -9,4 +9,9 @@
 public struct ExtensionDeclaration: Token {
     // TODO Implement support for extensions
     public let range: CountableRange<Int>
+
+    public func isEqual(to other: Token) -> Bool {
+        guard let other = other as? ExtensionDeclaration else { return false }
+        return self.range == other.range
+    }
 }

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/FileRepresentation.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/FileRepresentation.swift
@@ -35,15 +35,13 @@ internal extension Token {
             return self
         }
         let inheritedRepresentations: [Token] = typeToken.inheritedTypes
-                .map { Self.findToken(forClassOrProtocol: $0.name, in: files) }
-                .flatMap { $0 }
+                .flatMap { Self.findToken(forClassOrProtocol: $0.name, in: files) }
                 .flatMap { $0.mergeInheritance(with: files) }
 
         // Merge super declarations
         let mergedTokens = inheritedRepresentations.filter { $0.isClassOrProtocolDefinition }
                 .map { $0 as! ContainerToken }
-                .map { $0.children }
-                .flatMap { $0 }
+                .flatMap { $0.children }
                 .reduce(typeToken.children) { tokens, inheritedToken in
                     if (tokens.contains { $0 == inheritedToken }) {
                         return tokens
@@ -61,8 +59,7 @@ internal extension Token {
     }
 
     internal static func findToken(forClassOrProtocol name: String, in files: [FileRepresentation]) -> Token? {
-        return files.map { $0.declarations }
-                .flatMap { $0 }
+        return files.flatMap { $0.declarations }
                 .filter { $0.isClassOrProtocolDefinition }
                 .map { $0 as! ContainerToken }
                 .first { $0.name == name }

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/FileRepresentation.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/FileRepresentation.swift
@@ -35,7 +35,6 @@ internal extension Token {
             return self
         }
         let inheritedRepresentations: [Token] = typeToken.inheritedTypes
-                .map { $0 as! InheritanceDeclaration }
                 .map { Self.findToken(forClassOrProtocol: $0.name, in: files) }
                 .flatMap { $0 }
                 .flatMap { $0.mergeInheritance(with: files) }

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/FileRepresentation.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/FileRepresentation.swift
@@ -17,3 +17,55 @@ public struct FileRepresentation {
         self.declarations = declarations
     }
 }
+
+public extension FileRepresentation {
+    public func mergeInheritance(with files: [FileRepresentation]) -> FileRepresentation {
+        let tokens = self.declarations.reduce([Token]()) { list, token in
+            let mergeToken = token.mergeInheritance(with: files)
+            return list + [mergeToken]
+        }
+
+        return FileRepresentation(sourceFile: self.sourceFile, declarations: tokens)
+    }
+}
+
+internal extension Token {
+    internal func mergeInheritance(with files: [FileRepresentation]) -> Token {
+        guard let typeToken = self as? ContainerToken else {
+            return self
+        }
+        let inheritedRepresentations: [Token] = typeToken.inheritedTypes
+                .map { $0 as! InheritanceDeclaration }
+                .map { Self.findToken(forClassOrProtocol: $0.name, in: files) }
+                .flatMap { $0 }
+                .flatMap { $0.mergeInheritance(with: files) }
+
+        // Merge super declarations
+        let mergedTokens = inheritedRepresentations.filter { $0.isClassOrProtocolDefinition }
+                .map { $0 as! ContainerToken }
+                .map { $0.children }
+                .flatMap { $0 }
+                .reduce(typeToken.children) { tokens, inheritedToken in
+                    if (tokens.contains { $0 == inheritedToken }) {
+                        return tokens
+                    }
+                    return tokens + [inheritedToken]
+                }
+        switch typeToken {
+        case let classToken as ClassDeclaration:
+            return classToken.replace(children: mergedTokens)
+        case let protocolToken as ProtocolDeclaration:
+            return protocolToken.replace(children: mergedTokens)
+        default:
+            return typeToken
+        }
+    }
+
+    internal static func findToken(forClassOrProtocol name: String, in files: [FileRepresentation]) -> Token? {
+        return files.map { $0.declarations }
+                .flatMap { $0 }
+                .filter { $0.isClassOrProtocolDefinition }
+                .map { $0 as! ContainerToken }
+                .first { $0.name == name }
+    }
+}

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/Import.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/Import.swift
@@ -9,4 +9,9 @@
 public struct Import: Token {
     public let range: CountableRange<Int>
     public let library: String
+
+    public func isEqual(to other: Token) -> Bool {
+        guard let other = other as? Import else { return false }
+        return self.range == other.range && self.library == other.library
+    }
 }

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/InheritanceDeclaration.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/InheritanceDeclaration.swift
@@ -1,0 +1,17 @@
+//
+//  InheritanceDeclaration.swift
+//  CuckooGenerator
+//
+//  Created by Arjan Duijzer on 22/02/2017.
+//  Copyright (c) 2017 Brightify. All rights reserved.
+//
+
+public struct InheritanceDeclaration: Token {
+    public static let empty = InheritanceDeclaration(name: Tokenizer.nameNotSet)
+    public let name: String
+
+    public func isEqual(to other: Token) -> Bool {
+        guard let other = other as? InheritanceDeclaration else { return false }
+        return self.name == other.name
+    }
+}

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/InstanceVariable.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/InstanceVariable.swift
@@ -18,4 +18,9 @@ public struct InstanceVariable: Token {
     public var readOnly: Bool {
         return setterAccessibility == nil
     }
+
+    public func isEqual(to other: Token) -> Bool {
+        guard let other = other as? InstanceVariable else { return false }
+        return self.name == other.name
+    }
 }

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/Key.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/Key.swift
@@ -13,7 +13,8 @@ public enum Key: String {
     case SetterAccessibility = "key.setter_accessibility"
     case Name = "key.name"
     case TypeName = "key.typename"
-    
+    case InheritedTypes = "key.inheritedtypes"
+
     case Length = "key.length"
     case Offset = "key.offset"
     

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/Method.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/Method.swift
@@ -45,4 +45,9 @@ public extension Method {
             return "Void"
         }
     }
+
+    public func isEqual(to other: Token) -> Bool {
+        guard let other = other as? Method else { return false }
+        return self.name == other.name
+    }
 }

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/MethodParameter.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/MethodParameter.swift
@@ -24,4 +24,9 @@ public struct MethodParameter: Token {
     public var typeWithoutAttributes: String {
         return type.replacingOccurrences(of: "@escaping", with: "").replacingOccurrences(of: "@autoclosure", with: "").trimmed
     }
+
+    public func isEqual(to other: Token) -> Bool {
+        guard let other = other as? MethodParameter else { return false }
+        return self.name == other.name
+    }
 }

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ProtocolDeclaration.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ProtocolDeclaration.swift
@@ -15,7 +15,7 @@ public struct ProtocolDeclaration: ContainerToken {
     public let initializers: [Initializer]
     public let children: [Token]
     public let implementation: Bool = false
-    public let inheritedTypes: [Token]
+    public let inheritedTypes: [InheritanceDeclaration]
 
     public func replace(children tokens: [Token]) -> ProtocolDeclaration {
         return ProtocolDeclaration(name: self.name,

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ProtocolDeclaration.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ProtocolDeclaration.swift
@@ -15,4 +15,21 @@ public struct ProtocolDeclaration: ContainerToken {
     public let initializers: [Initializer]
     public let children: [Token]
     public let implementation: Bool = false
+    public let inheritedTypes: [Token]
+
+    public func replace(children tokens: [Token]) -> ProtocolDeclaration {
+        return ProtocolDeclaration(name: self.name,
+                accessibility: self.accessibility,
+                range: self.range,
+                nameRange: self.nameRange,
+                bodyRange: self.bodyRange,
+                initializers: self.initializers,
+                children: tokens,
+                inheritedTypes: self.inheritedTypes)
+    }
+
+    public func isEqual(to other: Token) -> Bool {
+        guard let other = other as? ProtocolDeclaration else { return false }
+        return self.name == other.name
+    }
 }

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/Token.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/Token.swift
@@ -6,4 +6,32 @@
 //  Copyright © 2016 Brightify. All rights reserved.
 //
 
-public protocol Token { }
+public protocol Token {
+    func isEqual(to other: Token) -> Bool
+}
+
+public func ==(rhs: Token, lhs: Token) -> Bool  {
+    return rhs.isEqual(to: lhs)
+}
+
+public extension Token {
+    public var isClassOrProtocolDefinition: Bool {
+        switch self {
+        case _ as ProtocolDeclaration:
+            fallthrough
+        case _ as ClassDeclaration:
+            return true
+        default:
+            return false
+        }
+    }
+
+    public var isInheritanceDefinition: Bool {
+        switch self {
+        case _ as InheritanceDeclaration:
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/Generator/Source/GenerateMocksCommand.swift
+++ b/Generator/Source/GenerateMocksCommand.swift
@@ -12,9 +12,9 @@ import SourceKittenFramework
 import FileKit
 import CuckooGeneratorFramework
 
-private func curry<P1, P2, P3, P4, P5, P6, P7, R>(_ f: @escaping (P1, P2, P3, P4, P5, P6, P7) -> R)
-    -> (P1) -> (P2) -> (P3) -> (P4) -> (P5) -> (P6) -> (P7) -> R {
-        return { p1 in { p2 in { p3 in { p4 in { p5 in { p6 in { p7 in f(p1, p2, p3, p4, p5, p6, p7) } } } } } } }
+private func curry<P1, P2, P3, P4, P5, P6, P7, P8, R>(_ f: @escaping (P1, P2, P3, P4, P5, P6, P7, P8) -> R)
+    -> (P1) -> (P2) -> (P3) -> (P4) -> (P5) -> (P6) -> (P7) -> (P8) -> R {
+        return { p1 in { p2 in { p3 in { p4 in { p5 in { p6 in { p7 in { p8 in f(p1, p2, p3, p4, p5, p6, p7, p8) } } } } } } } }
 }
 
 public struct GenerateMocksCommand: CommandProtocol {
@@ -26,8 +26,9 @@ public struct GenerateMocksCommand: CommandProtocol {
         let inputPathValues = Array(Set(options.files.map { Path($0).standardRawValue }))
         let inputFiles = inputPathValues.map { File(path: $0) }
         let tokens = inputFiles.flatMap { $0 }.map { Tokenizer(sourceFile: $0).tokenize() }
-        let parsedFiles = options.noClassMocking ? removeClasses(tokens) : tokens
-        
+        let tokensWithInheritance = options.noInheritance ? tokens : mergeInheritance(tokens)
+        let parsedFiles = options.noClassMocking ? removeClasses(tokensWithInheritance) : tokensWithInheritance
+
         let headers = parsedFiles.map { options.noHeader ? "" : FileHeaderHandler.getHeader(of: $0, includeTimestamp: !options.noTimestamp) }
         let imports = parsedFiles.map { FileHeaderHandler.getImports(of: $0, testableFrameworks: options.testableFrameworks) }
         let mocks = parsedFiles.map { Generator(file: $0).generate() }
@@ -56,7 +57,11 @@ public struct GenerateMocksCommand: CommandProtocol {
         let couldNotOpenFile = inputFiles.contains { $0 == nil }
         return stderrUsed || couldNotOpenFile ? .failure(.stderrUsed) : .success()
     }
-    
+
+    private func mergeInheritance(_ filesRepresentation: [FileRepresentation]) -> [FileRepresentation] {
+        return filesRepresentation.flatMap { $0.mergeInheritance(with: filesRepresentation) }
+    }
+
     private func removeClasses(_ filesRepresentation: [FileRepresentation]) -> [FileRepresentation] {
         return filesRepresentation.map {
                 let declarations = $0.declarations.filter { !($0 is ClassDeclaration) }
@@ -69,15 +74,17 @@ public struct GenerateMocksCommand: CommandProtocol {
         let output: String
         let noHeader: Bool
         let noTimestamp: Bool
+        let noInheritance: Bool
         let testableFrameworks: [String]
         let filePrefix: String
         let noClassMocking: Bool
-        
-        public init(output: String, testableFrameworks: String, noHeader: Bool, noTimestamp: Bool, filePrefix: String, noClassMocking: Bool, files: [String]) {
+
+        public init(output: String, testableFrameworks: String, noHeader: Bool, noTimestamp: Bool, noInheritance: Bool, filePrefix: String, noClassMocking: Bool, files: [String]) {
             self.output = output
             self.testableFrameworks = testableFrameworks.components(separatedBy: ",").filter { !$0.isEmpty }
             self.noHeader = noHeader
             self.noTimestamp = noTimestamp
+            self.noInheritance = noInheritance
             self.filePrefix = filePrefix
             self.files = files
             self.noClassMocking = noClassMocking
@@ -89,6 +96,7 @@ public struct GenerateMocksCommand: CommandProtocol {
                 <*> m <| Option(key: "testable", defaultValue: "", usage: "A comma separated list of frameworks that should be imported as @testable in the mock files.")
                 <*> m <| Option(key: "no-header", defaultValue: false, usage: "Do not generate file headers.")
                 <*> m <| Option(key: "no-timestamp", defaultValue: false, usage: "Do not generate timestamp.")
+                <*> m <| Option(key: "no-inheritance", defaultValue: false, usage: "Do not generate stubs/mock for super class/protocol even if available.")
                 <*> m <| Option(key: "file-prefix", defaultValue: "", usage: "Names of generated files in directory will start with this prefix. Only works when output path is directory.")
                 <*> m <| Option(key: "no-class-mocking", defaultValue: false, usage: "Do not generate mocks for classes.")
                 <*> m <| Argument(usage: "Files to parse and generate mocks for.")

--- a/Generator/Source/Supporting Files/Info.plist
+++ b/Generator/Source/Supporting Files/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.8.3</string>
+	<string>0.8.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ List of all changes and new features can be found [here](CHANGELOG.md).
 
 ## TODO
 
-We are still missing support for some important features like:
-* inheritance (grandparent methods)
-* generics
-* type inference for instance variables (you need to write it explicitly, otherwise it will be replaced with "__UnknownType")
+We are still missing support for some important features like:  
+
+* <del>inheritance (grandparent methods)</del>
+* generics  
+* type inference for instance variables (you need to write it explicitly, otherwise it will be replaced with "__UnknownType")  
 
 ## What will not be supported
 
@@ -87,7 +88,8 @@ ${PODS_ROOT}/Cuckoo/run generate --testable "$PROJECT_NAME" \
 
 Input files can be also specified directly in `Run script` in `Input Files` form. To force run script to rebuild generator even if it already exists, use `--clean` as first argument.
 
-Notes: All paths in the Run script must be absolute. Variable `PROJECT_DIR` automatically points to your project directory.
+Notes: All paths in the Run script must be absolute. Variable `PROJECT_DIR` automatically points to your project directory.  
+Also include paths to inherited Classes and Protocols for mocking/stubbing parent and grandparents.  
 
 #### Carthage
 To use Cuckoo with [Carthage](https://github.com/Carthage/Carthage) add in your Cartfile this line:
@@ -397,6 +399,10 @@ Do not generate file headers.
 
 Do not generate timestamp.
 
+##### `--no-inheritance`
+
+Do not mock/stub parents and grandparents.
+
 ##### `--file-prefix`
 
 Names of generated files in directory will start with this prefix. Only works when output path is directory.
@@ -419,6 +425,7 @@ After the `help` you can write name of another command for displaying a command-
 
 * Tadeas Kriz, [tadeas@brightify.org](mailto:tadeas@brightify.org)
 * Filip Dolník, [filip@brightify.org](mailto:filip@brightify.org)
+* Adriaan (Arjan) Duijzer [arjan@nxtstep.nl](mailto:arjan@nxtstep.nl)
 
 ## Inspiration
 

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.8.3</string>
+	<string>0.8.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Tests/Source/TestedSubProtocol.swift
+++ b/Tests/Source/TestedSubProtocol.swift
@@ -1,0 +1,11 @@
+//
+//  TestedSubProtocol.swift
+//  Cuckoo
+//
+//  Created by Arjan Duijzer on 22/02/2017.
+//  Copyright (c) 2017 Brightify. All rights reserved.
+//
+
+protocol TestedSubProtocol: TestedProtocol {
+    func noReturnSub()
+}

--- a/Tests/Source/TestedSubclass.swift
+++ b/Tests/Source/TestedSubclass.swift
@@ -1,0 +1,18 @@
+//
+//  TestedSubClass.swift
+//  Cuckoo
+//
+//  Created by Arjan Duijzer on 17/02/2017.
+//  Copyright © 2017 Brightify. All rights reserved.
+//
+
+class TestedSubclass: TestedClass, TestedProtocol {
+    // Should not be conflicting in mocked class
+    override func withThrows() throws -> Int {
+        return 1
+    }
+
+    func subclassMethod() -> Int {
+        return 0
+    }
+}

--- a/Tests/Stubbing/StubThrowingFunctionTest.swift
+++ b/Tests/Stubbing/StubThrowingFunctionTest.swift
@@ -55,6 +55,25 @@ class StubThrowingFunctionTest: XCTestCase {
         
         XCTAssertTrue(catched)
     }
+
+    func testOverrideThenThrowInSubClass() {
+        let mock = MockTestedSubclass()
+
+        XCTAssertNotNil(mock)
+
+        stub(mock) { mock in
+            when(mock.withThrows()).thenThrow(TestError.unknown)
+        }
+
+        var catched = false
+        do {
+            _ = try mock.withThrows()
+        } catch {
+            catched = true
+        }
+
+        XCTAssertTrue(catched)
+    }
     
     private enum TestError: Error {
         case unknown

--- a/Tests/Stubbing/StubbingTest.swift
+++ b/Tests/Stubbing/StubbingTest.swift
@@ -59,4 +59,31 @@ class StubbingTest: XCTestCase {
         XCTAssertEqual(mock.readOnlyProperty, "a")
         XCTAssertEqual(mock.count(characters: "a"), 1)
     }
+    
+    func testSubClass() {
+        let mock = MockTestedSubclass()
+        
+        XCTAssertNotNil(mock)
+        
+        stub(mock) { mock in
+            when(mock.readOnlyProperty.get).thenReturn("a").thenReturn("b", "c")
+        }
+        
+        XCTAssertEqual(mock.readOnlyProperty, "a")
+        XCTAssertEqual(mock.readOnlyProperty, "b")
+        XCTAssertEqual(mock.readOnlyProperty, "c")
+        XCTAssertEqual(mock.readOnlyProperty, "c")
+    }
+
+    func testSubClassMethod() {
+        let mock = MockTestedSubclass()
+
+        XCTAssertNotNil(mock)
+
+        stub(mock) { mock in
+            when(mock.subclassMethod()).thenReturn(1)
+        }
+
+        XCTAssertEqual(mock.subclassMethod(), 1)
+    }
 }


### PR DESCRIPTION
The Cuckoo generator can create Mocks and stubs for parents and grandparents methods, instance variables, and all other types that are mockable.

Implementation:
- First step is detecting inheritance types on the SourceKit returned type SourceKitRepresentable
- When creating the FileRepresentation array I've added a step that merges FileRepresentations
- The result of the merge is that all resolved Inherited types (when available in given input files) are flattened on the FileRepresentation.
- The merge checks for potential collisions on methods/types/etc.

Result:
Mock implementations have all of its own and (grand)parents methods and variables mocked and stubbed.
This assures that there will never be conflicts in parent or grandparent mocks while still being able to mock all methods/variables available.
